### PR TITLE
refactor: use snake case for runtime helpers

### DIFF
--- a/algorithms/base.py
+++ b/algorithms/base.py
@@ -262,6 +262,6 @@ class TradingAlgorithm(ABC):
         self.pca_resids = resids_new
         self.smoothed_series = smoothed_new
 
-    def RunStrategy(self,trade_log):
+    def run_strategy(self, trade_log):
         self.TradingStrategy(trade_log)
         return self.signals

--- a/backtesting/backtester.py
+++ b/backtesting/backtester.py
@@ -81,7 +81,7 @@ class Orchestrator:
         self.bot.retrain_full(self.data)
 
     # walk forward block 
-    def RetrainingCycle(self):
+    def retraining_cycle(self):
         '''
         pick up the next 15 points out of the time series, store in block times
         '''
@@ -107,10 +107,10 @@ class Orchestrator:
             # get the new row of prices, append to working data
             new_row = self.dataset_full.loc[[ts]]# type: ignore
             self.data = pd.concat([self.data, new_row])
-            self.bot.notify_new_point(new_row) # notify the new bot # type: ignore , 
+            self.bot.notify_new_point(new_row) # notify the new bot # type: ignore ,
 
             # get signals and log
-            signals = self.bot.RunStrategy(self.trades_log) or {}# type: ignore
+            signals = self.bot.run_strategy(self.trades_log) or {}# type: ignore
             self.trades_log.append({"time": ts, **signals})
 
             # quick step forward for overnight trading logic 
@@ -163,7 +163,7 @@ class Orchestrator:
         return equity
 
     # Point of entry to class
-    def RunOrchestrator(self):
+    def run_orchestrator(self):
         '''
         walk forward through the entire time series at once
         '''
@@ -172,7 +172,7 @@ class Orchestrator:
             self.first_pull()
 
         # loop until we run out of data
-        while self.RetrainingCycle():
+        while self.retraining_cycle():
             pass
 
         # if no trades are made, return an empty df 

--- a/backtesting/example_backtest.ipynb
+++ b/backtesting/example_backtest.ipynb
@@ -141,7 +141,7 @@
     "    sensitivity=0.01, \n",
     "    min_len=13, \n",
     "    bt_res=1\n",
-    "    ).RunOrchestrator() \n",
+    "    ).run_orchestrator() \n",
     "\n",
     "print('Pnl from run:',outs_mean_rev[1].iloc[-1])"
    ]
@@ -287,7 +287,7 @@
     "    sensitivity=0.001, \n",
     "    min_len=12, \n",
     "    bt_res=1\n",
-    "    ).RunOrchestrator() \n",
+    "    ).run_orchestrator() \n",
     "\n",
     "print('Pnl from run:',outs_market_neutral[1].iloc[-1])"
    ]

--- a/backtesting/parameter_optimiser.py
+++ b/backtesting/parameter_optimiser.py
@@ -60,7 +60,7 @@ def run_backtest(alpha, pcs_removed, unwind_rate, sensitivity, min_len):
         sensitivity=sensitivity,
         min_len=int(min_len),
         bt_res=3
-    ).RunOrchestrator()
+    ).run_orchestrator()
     
     # extracting information regarding backtest
     pnl_curve = outs[1]
@@ -92,3 +92,4 @@ if __name__ == "__main__":
     print('Market Neutral strat:')
     print("Best score:", -res.fun)
     print("Best params:", res.x)
+

--- a/backtesting/profiling.py
+++ b/backtesting/profiling.py
@@ -33,7 +33,7 @@ def run():
         sensitivity=0.02, 
         min_len=9, 
         bt_res = 1
-        ).RunOrchestrator() 
+        ).run_orchestrator()
     
 # run within profiler
 cProfile.run("run()", "profile.out")


### PR DESCRIPTION
## Summary
- rename `RunStrategy` to `run_strategy`
- rename orchestrator helpers to `run_orchestrator` and `retraining_cycle`
- update profiling scripts, optimiser, and notebook to use new names

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9acbf1a70833091b46bd103b3c8c4